### PR TITLE
Fix disappearing messages, and new chat button

### DIFF
--- a/components/chat-history.tsx
+++ b/components/chat-history.tsx
@@ -19,7 +19,7 @@ export async function ChatHistory({ userId }: ChatHistoryProps) {
       </div>
       <div className="mb-2 px-2">
         <Link
-          href="/"
+          href="/new"
           className={cn(
             buttonVariants({ variant: 'outline' }),
             'h-10 w-full justify-start bg-zinc-50 px-4 shadow-none transition-colors hover:bg-zinc-200/40 dark:bg-zinc-900 dark:hover:bg-zinc-300/10'

--- a/lib/chat/actions.tsx
+++ b/lib/chat/actions.tsx
@@ -415,7 +415,7 @@ async function submitUserMessage(content: string) {
         }
 
         // Update aiState
-        aiState.done({
+        aiState.update({
           ...aiState.get(),
           messages: [
             ...aiState.get().messages,


### PR DESCRIPTION
When I changed from update to done, I had not realized that calling aiState.done the second time will rewrite the first call contents. This led to missing messages in the saved chats.

The change from update to done was done earlier because I found that messages were not saved before they end streaming, and that was an issue with the functions timing out rather than aiState not working as expected. Regardless, the methods run on the edge now, and hopefully shouldn't time out before it finished responding.