### PR TITLE
Graph selection and follow-up query

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -34,11 +34,11 @@ export function ChatPanel({
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false)
 
   const exampleMessages: any[] = [
-    {
-      heading: 'What are the',
-      subheading: 'trending memecoins today?',
-      message: `Show me a line chart for temperaure and humidity for Chicago over any 10 consecutive days. The values are stored in hourly format, so average values over one day.`
-    },
+    // {
+    //   heading: 'What are the',
+    //   subheading: 'trending memecoins today?',
+    //   message: `What are the trending memecoins today?`
+    // },
     // {
     //   heading: 'What is the price of',
     //   subheading: '$DOGE right now?',

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -34,11 +34,11 @@ export function ChatPanel({
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false)
 
   const exampleMessages: any[] = [
-    // {
-    //   heading: 'What are the',
-    //   subheading: 'trending memecoins today?',
-    //   message: `What are the trending memecoins today?`
-    // },
+    {
+      heading: 'What are the',
+      subheading: 'trending memecoins today?',
+      message: `Show me a line chart for temperaure and humidity for Chicago over any 10 consecutive days. The values are stored in hourly format, so average values over one day.`
+    },
     // {
     //   heading: 'What is the price of',
     //   subheading: '$DOGE right now?',

--- a/components/graphs/graph.tsx
+++ b/components/graphs/graph.tsx
@@ -1,9 +1,12 @@
-import React, { useRef, useEffect, useMemo } from 'react';
+import React, { useRef, useEffect, useMemo, useId, useCallback } from 'react';
 import { Line, Bar } from 'react-chartjs-2';
 import { Chart, registerables, Interaction } from 'chart.js';
 import type { ChartData, ChartDataset, ChartOptions } from 'chart.js';
 import { LineBarGraphProps } from '@/lib/types';
 import { registerCrosshairPlugin } from './chart-crosshair-hotfix';
+import { useAIState } from 'ai/rsc'
+import { zoom } from 'chartjs-plugin-zoom';
+
 Chart.register(...registerables );
 registerCrosshairPlugin()
 
@@ -14,6 +17,31 @@ type LineOrBarOptions = ChartOptions<'line'> | ChartOptions<'bar'>;
 
 export function LineBarGraph({ props: { title, type, x, y1, y2 } }: { props: LineBarGraphProps }) { 
   const chartRef = useRef<Chart<any> | null>(null);
+  const [aiState, setAIState] = useAIState()
+  const id = useId()
+  
+  // const handleZoom = useCallback((chart: any) => {
+  //   const start = chart.chart.crosshair.start;
+  //   const end = chart.chart.crosshair.end;
+  //   console.log("THIS IS WHAT IS BEING SHOWN", start, end)
+  //   const follow_up_msg = {
+  //     id,
+  //     role: 'system' as const,
+  //     content: `[User has zoomed between x-axis index ${start} and ${end} in the above graph: ${title}. Give more details about the selected section in above graph]`
+  //   }
+
+  //   if (aiState.messages[aiState.messages.length - 1]?.id === id) {
+  //     setAIState({
+  //       ...aiState,
+  //       messages: [...aiState.messages.slice(0, -1), follow_up_msg]
+  //     })
+  //   } else {
+  //     setAIState({
+  //       ...aiState,
+  //       messages: [...aiState.messages, follow_up_msg]
+  //     })
+  //   }
+  // }, [id, title, aiState, setAIState])
 
   const data = useMemo<LineOrBarData>(() => ({
     labels: x.data,


### PR DESCRIPTION
Add the ability to ask follow-up questions on line and bar chart by selecting part of it, and asking questions based on that.